### PR TITLE
Add support for vanilla loot table prefix

### DIFF
--- a/src/main/java/dev/rosewood/roseloot/loot/condition/tags/VanillaLootTableCondition.java
+++ b/src/main/java/dev/rosewood/roseloot/loot/condition/tags/VanillaLootTableCondition.java
@@ -5,6 +5,7 @@ import dev.rosewood.roseloot.loot.context.LootContext;
 import dev.rosewood.roseloot.loot.context.LootContextParams;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.bukkit.NamespacedKey;
 
 public class VanillaLootTableCondition extends BaseLootCondition {
@@ -28,8 +29,18 @@ public class VanillaLootTableCondition extends BaseLootCondition {
 
         for (String value : values) {
             try {
-                this.vanillaLootTableKeys.add(NamespacedKey.fromString(value));
-            } catch (Exception ignored) { }
+                NamespacedKey namespacedKey;
+                if (value.indexOf(":") == -1) {
+                    namespacedKey = NamespacedKey.minecraft(value);
+                } else {
+                    String[] split = value.split(":", 2);
+                    String prefix = split[0];
+                    String key = split[1];
+                    namespacedKey = new NamespacedKey(prefix, key);
+                }
+                this.vanillaLootTableKeys.add(namespacedKey);
+            } catch (Exception ignored) {
+            }
         }
 
         return !this.vanillaLootTableKeys.isEmpty();


### PR DESCRIPTION
This PR add support for custom prefix for the `vanilla-loot-table` condition.

Previously, we were only able to set loot table coming from the `minecraft` namespace.
With this PR, we can set any namespace, for example `myplugin:myloot/stuff`.

This is useful if we want to create custom loot table with any namespace.

For now, the namespace key registering can only be done by a datapack. But it could be done by RoseLoot too using [Paper registry](https://docs.papermc.io/paper/dev/registries#mutating-registries), let me know if you want this PR too.