### PR TITLE
Added support for Craftengine

### DIFF
--- a/Plugin/build.gradle
+++ b/Plugin/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     compileOnly 'com.arcaniax:HeadDatabase-API:1.3.1', {
         exclude group: 'org.spigotmc'
     }
+    compileOnly 'net.momirealms:craft-engine-core:0.0.56'
+    compileOnly 'net.momirealms:craft-engine-bukkit:0.0.56'
+
 
     api "dev.rosewood:rosegarden:$rosegardenVersion"
     api "dev.rosewood:rosegarden-compatibility:$rosegardenVersion"

--- a/Plugin/src/main/java/dev/rosewood/roseloot/hook/CraftEngineHook.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/hook/CraftEngineHook.java
@@ -1,0 +1,15 @@
+package dev.rosewood.roseloot.hook;
+
+import org.bukkit.Bukkit;
+
+public class CraftEngineHook {
+
+    private static Boolean enabled;
+
+    public static boolean isEnabled() {
+        if (enabled != null)
+            return enabled;
+        return enabled = Bukkit.getPluginManager().getPlugin("CraftEngine") != null;
+    }
+
+}

--- a/Plugin/src/main/java/dev/rosewood/roseloot/hook/conditions/CraftEngineBlockCondition.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/hook/conditions/CraftEngineBlockCondition.java
@@ -1,0 +1,30 @@
+package dev.rosewood.roseloot.hook.conditions;
+
+import dev.rosewood.roseloot.listener.hook.CraftEngineBlockBreakListener;
+import dev.rosewood.roseloot.loot.condition.BaseLootCondition;
+import dev.rosewood.roseloot.loot.context.LootContext;
+
+import java.util.List;
+
+public class CraftEngineBlockCondition extends BaseLootCondition {
+
+    private List<String> blockTypes;
+
+    public CraftEngineBlockCondition(String tag) {
+        super(tag);
+    }
+
+    @Override
+    public boolean check(LootContext context) {
+        return context.get(CraftEngineBlockBreakListener.CRAFTENGINE_BLOCK)
+                .filter(this.blockTypes::contains)
+                .isPresent();
+    }
+
+    @Override
+    protected boolean parseValues(String[] values) {
+        this.blockTypes = List.of(values);
+        return !this.blockTypes.isEmpty();
+    }
+
+}

--- a/Plugin/src/main/java/dev/rosewood/roseloot/hook/conditions/HookConditionListener.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/hook/conditions/HookConditionListener.java
@@ -61,6 +61,10 @@ public class HookConditionListener implements Listener {
             event.registerLootCondition("nexo-block", NexoBlockCondition::new);
         }
 
+        if (pluginManager.getPlugin("CraftEngine") != null) {
+            event.registerLootCondition("craftengine-block", CraftEngineBlockCondition::new);
+        }
+
         if (pluginManager.getPlugin("CoreProtect") != null) {
             event.registerLootCondition("coreprotect-natural-block", CoreProtectNaturalBlockCondition::new);
         }

--- a/Plugin/src/main/java/dev/rosewood/roseloot/hook/items/CraftEngineItemProvider.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/hook/items/CraftEngineItemProvider.java
@@ -1,0 +1,28 @@
+package dev.rosewood.roseloot.hook.items;
+
+import dev.rosewood.roseloot.loot.context.LootContext;
+import net.momirealms.craftengine.bukkit.api.CraftEngineItems;
+import net.momirealms.craftengine.core.item.CustomItem;
+import net.momirealms.craftengine.core.util.Key;
+import org.bukkit.inventory.ItemStack;
+
+public class CraftEngineItemProvider extends ItemProvider {
+
+    public CraftEngineItemProvider() {
+        super("CraftEngine", true);
+    }
+
+    @Override
+    public ItemStack getItem(LootContext context, String id) {
+        if (!this.isEnabled()) return null;
+        CustomItem<ItemStack> itemStackCustomItem = CraftEngineItems.byId(Key.of(id));
+        return itemStackCustomItem == null ? null : itemStackCustomItem.buildItemStack();
+    }
+
+    @Override
+    public String getItemId(ItemStack item) {
+        if (!this.isEnabled()) return null;
+        Key customItemId = CraftEngineItems.getCustomItemId(item);
+        return customItemId == null ? null : customItemId.asString();
+    }
+}

--- a/Plugin/src/main/java/dev/rosewood/roseloot/hook/items/CustomItemPlugin.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/hook/items/CustomItemPlugin.java
@@ -33,7 +33,8 @@ public enum CustomItemPlugin {
     ZITEMS(ZItemProvider::new),
     ZESSENTIALS(ZEssentialsItemProvider::new),
     NEXO(NexoItemProvider::new),
-    CRAZYVOUCHERS(CrazyVouchersItemProvider::new);
+    CRAZYVOUCHERS(CrazyVouchersItemProvider::new),
+    CRAFTENGINE(CraftEngineItemProvider::new);
 
     private final Lazy<ItemProvider> itemProvider;
 

--- a/Plugin/src/main/java/dev/rosewood/roseloot/listener/hook/CraftEngineBlockBreakListener.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/listener/hook/CraftEngineBlockBreakListener.java
@@ -1,0 +1,87 @@
+package dev.rosewood.roseloot.listener.hook;
+
+import dev.rosewood.rosegarden.RosePlugin;
+import dev.rosewood.rosegarden.config.RoseConfig;
+import dev.rosewood.rosegarden.utils.EntitySpawnUtil;
+import dev.rosewood.roseloot.config.SettingKey;
+import dev.rosewood.roseloot.listener.helper.LazyLootTableListener;
+import dev.rosewood.roseloot.loot.LootContents;
+import dev.rosewood.roseloot.loot.LootResult;
+import dev.rosewood.roseloot.loot.context.LootContext;
+import dev.rosewood.roseloot.loot.context.LootContextParam;
+import dev.rosewood.roseloot.loot.context.LootContextParams;
+import dev.rosewood.roseloot.loot.table.LootTableTypes;
+import dev.rosewood.roseloot.manager.LootTableManager;
+import dev.rosewood.roseloot.util.LootUtils;
+import net.momirealms.craftengine.bukkit.api.event.CustomBlockBreakEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockDropItemEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CraftEngineBlockBreakListener extends LazyLootTableListener  {
+
+    public static final LootContextParam<String> CRAFTENGINE_BLOCK = LootContextParams.create("craftengine_block", String.class);
+
+    public CraftEngineBlockBreakListener(RosePlugin rosePlugin) {
+        super(rosePlugin, LootTableTypes.BLOCK);
+    }
+
+    @EventHandler
+    public void onCraftEngineBlockBreak(CustomBlockBreakEvent event) {
+        if (event.getPlayer().getGameMode() == org.bukkit.GameMode.CREATIVE)
+            return;
+
+        RoseConfig config = this.rosePlugin.getRoseConfig();
+        Block block = event.bukkitBlock();
+        if (config.get(SettingKey.DISABLED_WORLDS).stream().anyMatch(x -> x.equalsIgnoreCase(block.getWorld().getName())))
+            return;
+
+        Player player = event.getPlayer();
+        LootContext lootContext = LootContext.builder(LootUtils.getEntityLuck(player))
+                .put(LootContextParams.ORIGIN, block.getLocation())
+                .put(LootContextParams.LOOTER, player)
+                .put(LootContextParams.LOOTED_BLOCK, block)
+                .put(CRAFTENGINE_BLOCK, event.customBlock().id().asString())
+                .build();
+        LootResult lootResult = this.rosePlugin.getManager(LootTableManager.class).getLoot(LootTableTypes.BLOCK, lootContext);
+        if (lootResult.isEmpty())
+            return;
+
+        LootContents lootContents = lootResult.getLootContents();
+
+        // Drop items and experience
+        Location dropLocation = block.getLocation().add(0.5, 0.5, 0.5);
+        List<Item> droppedItems = new ArrayList<>();
+        lootContents.getItems().forEach(x -> droppedItems.add(block.getWorld().dropItemNaturally(dropLocation, x)));
+
+        // Simulate a BlockDropItemEvent for each item dropped for better custom enchantment plugin support if enabled
+        if (!droppedItems.isEmpty() && config.get(SettingKey.SIMULATE_BLOCKDROPITEMEVENT)) {
+            List<Item> eventItems = new ArrayList<>(droppedItems);
+            BlockDropItemEvent blockDropItemEvent = new BlockDropItemEvent(block, block.getState(), player, eventItems);
+            Bukkit.getPluginManager().callEvent(blockDropItemEvent);
+            if (!blockDropItemEvent.isCancelled()) {
+                droppedItems.stream().filter(x -> !eventItems.contains(x)).forEach(Entity::remove);
+            } else {
+                droppedItems.forEach(Entity::remove);
+            }
+        }
+
+        int experience = lootContents.getExperience();
+        if (experience > 0) {
+            Location location = player.getLocation();
+            EntitySpawnUtil.spawn(location, ExperienceOrb.class, x -> x.setExperience(experience));
+        }
+
+        lootContents.triggerExtras(dropLocation);
+    }
+
+}

--- a/Plugin/src/main/java/dev/rosewood/roseloot/manager/LazyListenerManager.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/manager/LazyListenerManager.java
@@ -2,10 +2,7 @@ package dev.rosewood.roseloot.manager;
 
 import dev.rosewood.rosegarden.RosePlugin;
 import dev.rosewood.rosegarden.utils.NMSUtil;
-import dev.rosewood.roseloot.hook.ItemsAdderHook;
-import dev.rosewood.roseloot.hook.NexoHook;
-import dev.rosewood.roseloot.hook.OraxenHook;
-import dev.rosewood.roseloot.hook.RoseStackerHook;
+import dev.rosewood.roseloot.hook.*;
 import dev.rosewood.roseloot.listener.AdvancementListener;
 import dev.rosewood.roseloot.listener.ArchaeologyListener;
 import dev.rosewood.roseloot.listener.BlockListener;
@@ -17,10 +14,7 @@ import dev.rosewood.roseloot.listener.LootGenerateListener;
 import dev.rosewood.roseloot.listener.PiglinBarterListener;
 import dev.rosewood.roseloot.listener.VaultListener;
 import dev.rosewood.roseloot.listener.helper.LazyListener;
-import dev.rosewood.roseloot.listener.hook.ItemsAdderBlockBreakListener;
-import dev.rosewood.roseloot.listener.hook.NexoBlockBreakListener;
-import dev.rosewood.roseloot.listener.hook.OraxenBlockBreakListener;
-import dev.rosewood.roseloot.listener.hook.RoseStackerEntityDeathListener;
+import dev.rosewood.roseloot.listener.hook.*;
 import dev.rosewood.roseloot.listener.paper.FallingBlockListener;
 import dev.rosewood.roseloot.listener.paper.NewerPaperListener;
 import dev.rosewood.roseloot.listener.paper.PaperListener;
@@ -63,6 +57,8 @@ public class LazyListenerManager extends DelayedManager {
             this.lazyListeners.add(new OraxenBlockBreakListener(rosePlugin));
         if (NexoHook.isEnabled())
             this.lazyListeners.add(new NexoBlockBreakListener(rosePlugin));
+        if (CraftEngineHook.isEnabled())
+            this.lazyListeners.add(new CraftEngineBlockBreakListener(rosePlugin));
 
         try {
             // PiglinBarterEvent was added to the 1.16.5 API right before 1.17 was released,

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -48,6 +48,7 @@ softdepend:
   - AdvancedItems
   - CustomFishing
   - BlockTracker
+  - CraftEngine
 permissions:
   roseloot.basecommand:
     description: Allows using the RoseLoot commands


### PR DESCRIPTION
```
type: BLOCK
overwrite-existing: items
conditions:
  - 'craftengine-block:default:chinese_lantern'
pools: 
  0:
    conditions: []
    rolls: 1
    bonus-rolls: 0
    entries:
      0:
        conditions: []
        items:
          0:
            type: custom_item
            plugin: craftengine
            item: 'default:topaz'
            amount: 1
```
