### PR TITLE
Add support for JustLootIt

### DIFF
--- a/Plugin/build.gradle
+++ b/Plugin/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     }
     compileOnly 'net.momirealms:craft-engine-core:0.0.56'
     compileOnly 'net.momirealms:craft-engine-bukkit:0.0.56'
+    compileOnly 'me.lauriichan.spigot.justlootit:justlootit-core:2.17.0:shaded'
 
     api "dev.rosewood:rosegarden:$rosegardenVersion"
     api "dev.rosewood:rosegarden-compatibility:$rosegardenVersion"

--- a/Plugin/src/main/java/dev/rosewood/roseloot/hook/JustLootItHook.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/hook/JustLootItHook.java
@@ -1,0 +1,15 @@
+package dev.rosewood.roseloot.hook;
+
+import org.bukkit.Bukkit;
+
+public class JustLootItHook {
+
+    private static Boolean enabled;
+
+    public static boolean isEnabled() {
+        if (enabled != null)
+            return enabled;
+        return enabled = Bukkit.getPluginManager().getPlugin("JustLootIt") != null;
+    }
+
+}

--- a/Plugin/src/main/java/dev/rosewood/roseloot/listener/hook/JustLootItLootGenerateListener.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/listener/hook/JustLootItLootGenerateListener.java
@@ -1,0 +1,69 @@
+package dev.rosewood.roseloot.listener.hook;
+
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.inventory.ItemStack;
+
+import dev.rosewood.rosegarden.RosePlugin;
+import dev.rosewood.rosegarden.utils.EntitySpawnUtil;
+import dev.rosewood.roseloot.config.SettingKey;
+import dev.rosewood.roseloot.listener.helper.LazyLootTableListener;
+import dev.rosewood.roseloot.loot.LootContents;
+import dev.rosewood.roseloot.loot.LootResult;
+import dev.rosewood.roseloot.loot.OverwriteExisting;
+import dev.rosewood.roseloot.loot.context.LootContext;
+import dev.rosewood.roseloot.loot.context.LootContextParams;
+import dev.rosewood.roseloot.loot.table.LootTableTypes;
+import dev.rosewood.roseloot.manager.LootTableManager;
+import dev.rosewood.roseloot.util.LootUtils;
+import me.lauriichan.spigot.justlootit.api.event.player.JLIPlayerLootProvidedEvent;
+import me.lauriichan.spigot.justlootit.api.event.player.JLIPlayerVanillaLootProvidedEvent;
+
+public class JustLootItLootGenerateListener extends LazyLootTableListener {
+
+    public JustLootItLootGenerateListener(RosePlugin rosePlugin) {
+        super(rosePlugin, LootTableTypes.CONTAINER);
+    }
+
+    @EventHandler
+    public void onLootProvided(JLIPlayerLootProvidedEvent event) {
+        if (this.rosePlugin.getRoseConfig().get(SettingKey.DISABLED_WORLDS).stream().anyMatch(x -> x.equalsIgnoreCase(event.entryLocation().getWorld().getName())))
+            return;
+
+        Player looter = event.player().asBukkit();
+
+        LootContext.Builder contextBuilder = LootContext.builder(LootUtils.getEntityLuck(looter))
+            .put(LootContextParams.ORIGIN, event.entryLocation())
+            .put(LootContextParams.LOOTER, looter)
+            // Usually JLI loot containers always contain loot when this event is triggered
+            // There is only the exception for when a loot table doesn't generate any or a static container is kept empty for unknown reasons
+            // However that should be the exception so we just *expect* loot to be there
+            .put(LootContextParams.HAS_EXISTING_ITEMS, true);
+        if (event.entryHolder() instanceof BlockState state)
+            contextBuilder.put(LootContextParams.LOOTED_BLOCK, state.getBlock());
+        if (event instanceof JLIPlayerVanillaLootProvidedEvent vanillaEvent)
+            contextBuilder.put(LootContextParams.VANILLA_LOOT_TABLE_KEY, vanillaEvent.lootTable().getKey());
+
+        LootResult lootResult = this.rosePlugin.getManager(LootTableManager.class).getLoot(LootTableTypes.CONTAINER, contextBuilder.build());
+        if (lootResult.isEmpty())
+            return;
+
+        LootContents lootContents = lootResult.getLootContents();
+
+        // Overwrite existing loot if applicable
+        if (lootResult.doesOverwriteExisting(OverwriteExisting.ITEMS))
+            event.inventory().clear();
+
+        // Set items and drop experience
+        event.bukkitInventory().addItem(lootResult.getLootContents().getItems().toArray(ItemStack[]::new));
+
+        int experience = lootContents.getExperience();
+        if (experience > 0)
+            EntitySpawnUtil.spawn(looter.getLocation(), ExperienceOrb.class, x -> x.setExperience(experience));
+
+        lootContents.triggerExtras(event.entryLocation());
+    }
+
+}

--- a/Plugin/src/main/java/dev/rosewood/roseloot/manager/LazyListenerManager.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/manager/LazyListenerManager.java
@@ -4,6 +4,7 @@ import dev.rosewood.rosegarden.RosePlugin;
 import dev.rosewood.rosegarden.utils.NMSUtil;
 import dev.rosewood.roseloot.hook.CraftEngineHook;
 import dev.rosewood.roseloot.hook.ItemsAdderHook;
+import dev.rosewood.roseloot.hook.JustLootItHook;
 import dev.rosewood.roseloot.hook.NexoHook;
 import dev.rosewood.roseloot.hook.OraxenHook;
 import dev.rosewood.roseloot.hook.RoseStackerHook;
@@ -20,6 +21,7 @@ import dev.rosewood.roseloot.listener.VaultListener;
 import dev.rosewood.roseloot.listener.helper.LazyListener;
 import dev.rosewood.roseloot.listener.hook.CraftEngineBlockBreakListener;
 import dev.rosewood.roseloot.listener.hook.ItemsAdderBlockBreakListener;
+import dev.rosewood.roseloot.listener.hook.JustLootItLootGenerateListener;
 import dev.rosewood.roseloot.listener.hook.NexoBlockBreakListener;
 import dev.rosewood.roseloot.listener.hook.OraxenBlockBreakListener;
 import dev.rosewood.roseloot.listener.hook.RoseStackerEntityDeathListener;
@@ -67,6 +69,8 @@ public class LazyListenerManager extends DelayedManager {
             this.lazyListeners.add(new NexoBlockBreakListener(rosePlugin));
         if (CraftEngineHook.isEnabled())
             this.lazyListeners.add(new CraftEngineBlockBreakListener(rosePlugin));
+        if (JustLootItHook.isEnabled())
+            this.lazyListeners.add(new JustLootItLootGenerateListener(rosePlugin));
 
         try {
             // PiglinBarterEvent was added to the 1.16.5 API right before 1.17 was released,

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -52,6 +52,7 @@ softdepend:
   - AuraSkills
   - CoinsEngine
   - ExcellentEconomy
+  - JustLootIt
 permissions:
   roseloot.basecommand:
     description: Allows using the RoseLoot commands

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ allprojects {
         maven { url = 'https://repo.nightexpressdev.com/releases'}
         maven { url = 'https://libraries.minecraft.net/' }
         maven { url = 'https://jitpack.io/' }
+        maven { url = 'https://mvn.lumine.io/repository/maven-public/' }
         maven { url = 'https://maven.lauriichan.me/release' }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ allprojects {
         maven { url = 'https://repo.nightexpressdev.com/releases'}
         maven { url = 'https://libraries.minecraft.net/' }
         maven { url = 'https://jitpack.io/' }
+        maven { url = 'https://maven.lauriichan.me/release' }
     }
 
     dependencies {


### PR DESCRIPTION
This PR adds support for my plugin JustLootIt to RoseLoot.

It also fixes that the MythicMobs repository is missing from the build.gradle file so that other people trying to contribute don't run into this issue.