### PR TITLE
feat: Remove onLootTableGenerate event handler

### DIFF
--- a/Plugin/src/main/java/dev/rosewood/roseloot/listener/EntityListener.java
+++ b/Plugin/src/main/java/dev/rosewood/roseloot/listener/EntityListener.java
@@ -30,14 +30,6 @@ public class EntityListener extends LazyLootTableListener {
         super(rosePlugin, LootTableTypes.ENTITY);
     }
 
-    @EventHandler
-    public void onLootTableGenerate(PostLootTableGenerateEvent event) {
-        if (event.getLootTable().getType() != LootTableTypes.ENTITY)
-            return;
-
-        System.out.println("blargh");
-    }
-
     @EventHandler(priority = EventPriority.LOW) // changing to LOW so worldguard flags detect changes properly
     public void onEntityDeath(EntityDeathEvent event) {
         LivingEntity entity = event.getEntity();


### PR DESCRIPTION
This pull request makes a minor cleanup to the `EntityListener` by removing an unused event handler method from unnecessary debug statements:
→ Removed the [`onLootTableGenerate`](https://github.com/Rosewood-Development/RoseLoot/pull/50/changes#diff-812141d0c1f9b2719a27040de3ad28e97ef676cfd037430dc1e68f19f7dc841e) method, which was unused and contained only a debug print.